### PR TITLE
Add closing braces to Vite config

### DIFF
--- a/content/docs/installation/frameworks/laravel.md
+++ b/content/docs/installation/frameworks/laravel.md
@@ -40,7 +40,7 @@ Create an `emails` directory inside `resources/js` for your email templates:
 
 Register the Maizzle Vite plugin in your `vite.config.ts`:
 
-```ts {5,15-23}
+```ts {5,15-24}
 import laravel from 'laravel-vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'


### PR DESCRIPTION
At the moment the closing braces aren't highlighted which could be confusing when copy/pasting.

<img width="810" height="325" alt="image" src="https://github.com/user-attachments/assets/63c2d184-c244-421d-b9ed-1bb49edf788c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Laravel installation guide code example to improve visual clarity of highlighted configuration lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->