### PR TITLE
Remove the path suffix

### DIFF
--- a/content/docs/installation/frameworks/laravel.md
+++ b/content/docs/installation/frameworks/laravel.md
@@ -56,7 +56,7 @@ export default defineConfig({
     tailwindcss(),
     vue(),
     maizzle({
-      root: 'resources/js/emails',
+      root: 'resources/js',
       output: {
         path: 'resources/views/emails',
         extension: 'blade.php',


### PR DESCRIPTION
It looks like Maizzle looks for an `emails` directory in the content path, so this root means Maizzle is looking in `resources/js/emails/emails` which seems incorrect.

---

The other thing I might suggest is removing the `static` option from this configuration as I'm not sure it will work in this Laravel setup. The emails are output to a private directory that is not web-accessible. Laravel users can instead use it's own asset handling. Can PR that change also if you agree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Laravel framework documentation with revised Maizzle Vite plugin configuration.
  * Clarified that static asset copying should not be used for Laravel email images.
  * Added guidance to store images in Laravel’s public directory and reference them with absolute URLs.
  * Updated the project structure and configuration examples to reflect these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->